### PR TITLE
feat: Implement hover-activated horizontal scroll for news ticker

### DIFF
--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1539,33 +1539,50 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  // --- Scroll automatico news-ticker continuo (unica versione) ---
+  // --- Scroll news-ticker on hover ---
   let newsTickerScrollInterval = null;
 
-  function startContinuousNewsTickerScroll() {
-    // Ferma eventuali intervalli precedenti
-    if (newsTickerScrollInterval) {
-      clearInterval(newsTickerScrollInterval);
-      newsTickerScrollInterval = null;
-    }
-    const ticker = document.querySelector('#news-ticker .overflow-x-auto');
-    if (!ticker) {
-      console.log('[NewsTicker] Contenitore non trovato');
+  function startHoverScrollEffect() {
+    const newsTickerContainer = document.getElementById('news-ticker');
+    if (!newsTickerContainer) {
       return;
     }
-    console.log('[NewsTicker] Scroll automatico avviato');
-    newsTickerScrollInterval = setInterval(() => {
-      ticker.scrollLeft += 2;
-      if (ticker.scrollLeft + ticker.clientWidth >= ticker.scrollWidth - 2) {
-        ticker.scrollLeft = 0;
+    const scrollableArea = newsTickerContainer.querySelector('.overflow-x-auto');
+    if (!scrollableArea) {
+      return;
+    }
+    newsTickerContainer.addEventListener('mouseenter', () => {
+      if (newsTickerScrollInterval) {
+        clearInterval(newsTickerScrollInterval);
       }
-    }, 16);
+      newsTickerScrollInterval = setInterval(() => {
+        scrollableArea.scrollLeft += 2;
+        if (scrollableArea.scrollLeft + scrollableArea.clientWidth >= scrollableArea.scrollWidth - 2) {
+          scrollableArea.scrollLeft = 0;
+        }
+      }, 16);
+    });
+    newsTickerContainer.addEventListener('mouseleave', () => {
+      if (newsTickerScrollInterval) {
+        clearInterval(newsTickerScrollInterval);
+        newsTickerScrollInterval = null;
+      }
+    });
   }
 
-  document.addEventListener('DOMContentLoaded', startContinuousNewsTickerScroll);
+  function initNewsTicker() {
+    startHoverScrollEffect();
+  }
+
+  if (document.readyState === 'interactive' || document.readyState === 'complete') {
+    initNewsTicker();
+  } else {
+    document.addEventListener('DOMContentLoaded', initNewsTicker); // Simplified listener
+  }
+
   document.body.addEventListener('htmx:afterSwap', function(evt) {
     if (evt.detail && evt.detail.target && evt.detail.target.id === 'news-ticker') {
-      startContinuousNewsTickerScroll();
+      startHoverScrollEffect();
     }
   });
 });


### PR DESCRIPTION
This commit introduces a hover-activated horizontal scrolling feature for the news ticker element (`#news-ticker`).

Key changes in `static/js/ui.js`:
- The news ticker now automatically scrolls horizontally when your mouse hovers over it.
- Scrolling pauses when the mouse cursor leaves the news ticker area.
- The scroll loops back to the beginning when it reaches the end of the content.
- Initialization of this effect correctly handles DOM readiness by checking `document.readyState` and using the `DOMContentLoaded` event.
- The effect is re-initialized if the `#news-ticker` element is updated or replaced via an HTMX swap, ensuring consistent behavior.
- All diagnostic console logs have been removed.

This functionality relies on the `#news-ticker` element and its child with the class `.overflow-x-auto` being present in the DOM as expected.