### PR TITLE
Align home page highlights visibility with resource permissions

### DIFF
--- a/app/contatti.py
+++ b/app/contatti.py
@@ -70,9 +70,17 @@ async def create_contact(
         # --- AGGIUNTA BROADCAST HIGHLIGHT ---
         try:
             payload_highlight = {
-                "type": "refresh_home_highlights"
+                "type": "refresh_home_highlights",
+                # Includiamo branch e employment_type per il filtraggio nel broadcast
+                # Questi verranno usati da ws_broadcast.py se il tipo è refresh_home_highlights
+                "data": {
+                    "branch": branch,
+                    "employment_type": employment_type_list
+                }
             }
-            await broadcast_message(payload_highlight)
+            # Passiamo branch e employment_type anche come argomenti diretti a broadcast_message
+            # per assicurarci che ws_broadcast li usi per filtrare i destinatari.
+            await broadcast_message(payload_highlight, branch=branch, employment_type=employment_type_list)
         except Exception as e:
             print("[WebSocket] Errore broadcast su update_contact_highlight:", e)
         # --- FINE AGGIUNTA ---


### PR DESCRIPTION
- Modified `app/contatti.py` to send `branch` and `employment_type` with the `refresh_home_highlights` WebSocket message. This allows `ws_broadcast.py` to filter recipients for this message.
- Modified `main.py` (`home_highlights_partial` route) to filter highlights fetched from the database based on the requesting user's `branch` and `employment_type`.
- This ensures that users only receive signals to refresh home highlights if the new/updated contact is relevant to them, and that the home page itself only displays highlights accessible to the user.