### PR TITLE
Refactor: Consolidate news CRUD routes in app/news.py

### DIFF
--- a/templates/news/news_edit_partial.html
+++ b/templates/news/news_edit_partial.html
@@ -61,6 +61,27 @@
       </div>
     </fieldset>
 
+    <!-- Priorità -->
+    <div>
+      <label for="priority" class="text-sm font-medium text-slate-700">Priorità (1 più alta)</label>
+      <input type="number"
+             name="priority"
+             id="priority"
+             value="{{ n.priority | default(3) }}"
+             min="1" max="5"
+             class="block w-full rounded-lg border border-slate-200 px-4 py-3 text-base focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50 transition">
+    </div>
+
+    <!-- Data Scadenza -->
+    <div>
+      <label for="expires_at_str" class="text-sm font-medium text-slate-700">Data Scadenza (opzionale)</label>
+      <input type="date"
+             name="expires_at_str"
+             id="expires_at_str"
+             value="{{ n.expires_at.strftime('%Y-%m-%d') if n.expires_at else '' }}"
+             class="block w-full rounded-lg border border-slate-200 px-4 py-3 text-base focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50 transition">
+    </div>
+
     <!-- Evidenza in home -->
     <label class="inline-flex items-center gap-2 text-sm text-slate-700">
       <input type="checkbox"

--- a/templates/news/news_new.html
+++ b/templates/news/news_new.html
@@ -47,6 +47,18 @@
     {% include "components/branch_and_hire_selects.html" %}
   </fieldset>
 
+  <!-- Priorità -->
+  <div class="grid gap-2">
+    <label class="text-sm font-medium text-slate-700" for="priority">Priorità (1 più alta, default 3)</label>
+    <input name="priority" id="priority" type="number" value="3" min="1" max="5" class="block w-full rounded-lg border border-slate-200 px-4 py-3 text-base focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50 transition">
+  </div>
+
+  <!-- Data Scadenza -->
+  <div class="grid gap-2">
+    <label class="text-sm font-medium text-slate-700" for="expires_at_str">Data Scadenza (opzionale)</label>
+    <input name="expires_at_str" id="expires_at_str" type="date" class="block w-full rounded-lg border border-slate-200 px-4 py-3 text-base focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50 transition">
+  </div>
+
   <!-- Evidenza in home -->
   <label class="inline-flex items-center gap-2 text-sm text-slate-700">
     <input type="checkbox" id="show_on_home" name="show_on_home" value="true" class="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500">


### PR DESCRIPTION
- Commented out duplicated route definitions for news creation, editing, and deletion (those without the `/news/` prefix and often suffixed with `_global`).
- Integrated `priority` and `expires_at` functionality into the primary `/news/...` routes.
- The `create_news` function (`POST /news/new`) now accepts optional `priority` and `expires_at_str` parameters.
- The `edit_news_submit` function (`POST /news/{news_id}/edit`) now accepts optional `priority` and `expires_at_str` parameters and updates them only if provided.
- Updated `templates/news/news_new.html` and `templates/news/news_edit_partial.html` to include form fields for `priority` and `expires_at`.

This change centralizes news management logic, removes redundancy, and ensures all news features are accessible via a consistent set of endpoints.