### PR TITLE
Fix: Correct link notification badge display

### DIFF
--- a/app/notifiche.py
+++ b/app/notifiche.py
@@ -237,7 +237,7 @@ async def notifiche_count_link(request: Request, user=Depends(get_current_user))
     count = await db.notifiche.count_documents(q)
     return request.app.state.templates.TemplateResponse(
         "components/nav_links_badge.html",
-        {"request": request, "unread_link_count": "" if count == 0 else count, "u": user}
+        {"request": request, "unread_links_count": "" if count == 0 else count, "u": user} # Corretto: unread_links_count
     )
 
 


### PR DESCRIPTION
- Corrected a typo in `app/notifiche.py` within the `notifiche_count_link` function. The context variable passed to the `nav_links_badge.html` template is now `unread_links_count` (was `unread_link_count`) for consistency.
- Verified that `templates/components/nav_links_badge.html` correctly uses the `unread_links_count` variable and has the appropriate HTMX attributes for dynamic updates.
- Confirmed that the existing JavaScript notification system (`websocket.js`, `badge.js`) is generic and should correctly trigger badge updates for link notifications without modification.