### PR TITLE
Fix: Link notification badge not appearing for recipient

### DIFF
--- a/static/js/features/notifications/badge.js
+++ b/static/js/features/notifications/badge.js
@@ -10,14 +10,20 @@ import { eventBus } from "../../core/event-bus.js";
  *         hx-target="this">0</span>
  */
 export function initBadges() {
-  // 1) Primo caricamento
+  // 1) Primo caricamento: scatena un refresh di tutti i badge HTMX
   htmx.trigger("body", "notifications.refresh");
 
-  // 2) Ogni nuova notifica -> refresh badge
-  eventBus.on("notifications/new", () => {
-    htmx.trigger("body", "notifications.refresh");
-  });
+  // 2) Il refresh dei badge in risposta a nuove notifiche WebSocket
+  // è gestito da `static/js/features/notifications/websocket.js`.
+  // Quel file ascolta `new_notification` dall'event bus (emesso da `core/websocket.js`)
+  // e poi esegue `htmx.trigger('body', 'notifications.refresh');`.
+  // Quindi, un listener separato qui per un evento `notifications/new` è ridondante
+  // e potenzialmente confuso se l'evento non viene emesso come previsto.
+  // eventBus.on("notifications/new", () => {
+  //   log.debug('Evento notifications/new ricevuto, aggiorno i badge.');
+  //   htmx.trigger("body", "notifications.refresh");
+  // });
 }
 
 // auto-bootstrap
-initBadges(); 
+initBadges();


### PR DESCRIPTION
- Ensured `crea_notifica` is called in `app/links.py` when a new link is created, so the notification is saved to the database. This allows the link notification badge to be correctly counted and displayed.
- Removed a redundant event listener in `static/js/features/notifications/badge.js` as the badge refresh mechanism was already correctly handled by `features/notifications/websocket.js` triggering an HTMX refresh.