### PR TITLE
Align AI News CRUD with Links section behavior

### DIFF
--- a/static/js/features/ai-news-delete.js
+++ b/static/js/features/ai-news-delete.js
@@ -1,0 +1,97 @@
+import { eventBus } from '/static/js/core/event-bus.js';
+
+// This function can be called to initialize delete functionality for AI News items.
+// It expects delete buttons to have 'data-delete-url' and 'data-item-id' attributes.
+// The 'data-delete-url' should point to the DELETE endpoint for the AI news item.
+// The 'data-item-id' is the ID of the news item, used for removing the element from the UI.
+export function initAiNewsDeleteConfirmation() {
+  document.body.addEventListener('click', async (event) => {
+    const deleteButton = event.target.closest('button[data-delete-url][data-item-id]');
+
+    if (!deleteButton) {
+      return; // Click was not on a delete button for AI News
+    }
+
+    event.preventDefault(); // Prevent default form submission if it's a submit button
+
+    const deleteUrl = deleteButton.dataset.deleteUrl;
+    const itemId = deleteButton.dataset.itemId;
+    const itemName = deleteButton.dataset.itemName || 'questo elemento'; // Fallback item name
+
+    // Show SweetAlert confirmation
+    const result = await Swal.fire({
+      title: 'Sei sicuro?',
+      html: `Vuoi davvero eliminare <strong>${itemName}</strong>?<br>Questa azione non può essere annullata.`,
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonText: 'Sì, elimina!',
+      cancelButtonText: 'Annulla',
+      confirmButtonColor: '#d33',
+      cancelButtonColor: '#3085d6',
+      reverseButtons: true,
+    });
+
+    if (result.isConfirmed) {
+      // User confirmed, proceed with the delete request using HTMX if the button is part of an HTMX form
+      // or manually if not.
+      // For consistency with the row_partial.html which has <form hx-delete="...">,
+      // we assume the button might be inside such a form.
+      // If the button itself is the hx-delete trigger, HTMX handles it.
+      // This script primarily adds the confirmation step.
+
+      const htmxForm = deleteButton.closest('form[hx-delete]');
+      if (htmxForm) {
+        // If the button is inside an HTMX form, let HTMX handle the submission.
+        // HTMX will make the DELETE request.
+        // We might need to manually trigger the request if the button isn't a submit type
+        // or if the form submission needs to be explicitly invoked.
+        // For now, assuming HTMX handles it or the button itself has hx-delete.
+        // If the button itself is `hx-delete`, this JS confirmation runs before HTMX processes the click.
+        console.log(`HTMX form found for ${itemId}, allowing HTMX to proceed.`);
+        // If the button is NOT type="submit" or not directly triggering hx-delete,
+        // you might need to do: htmx.trigger(htmxForm, "submit"); or htmx.ajax('DELETE', deleteUrl, {target: `#ai-news-${itemId}`, swap: 'delete'});
+        // However, the current ai_news/row_partial.html has onclick="showDelete(this)" which this replaces.
+        // The form itself has hx-delete. So, if this button is a submit button, it will trigger.
+        // If it's just a button, we need to trigger the form or make the call.
+
+        // Let's assume the button IS the trigger or is type=submit in an hx-form.
+        // If not, this part needs adjustment. The goal is for this script to *just* confirm.
+        // The actual hx-delete on the form in row_partial.html will handle the request and removal.
+        // If the button itself has hx-delete, HTMX will also pick it up.
+        // This function is primarily for the SweetAlert confirmation.
+      } else {
+        // Fallback: if no HTMX form, make a manual fetch (less ideal if HTMX is used elsewhere for this)
+        console.warn(`No HTMX form with hx-delete found for ${itemId}. Consider using HTMX for deletion.`);
+        // This manual fetch block is a fallback and might not be needed if row_partial.html is correctly set up.
+        try {
+          const response = await fetch(deleteUrl, {
+            method: 'DELETE',
+            headers: {
+              'X-Requested-With': 'XMLHttpRequest', // Standard header for AJAX
+              // 'HX-Request': 'true' // If server specifically checks for this
+            },
+          });
+
+          if (response.ok) {
+            const itemElement = document.getElementById(`ai-news-${itemId}`);
+            if (itemElement) {
+              itemElement.remove();
+            }
+            // Admin confirmation will be handled by HX-Trigger from server if any
+            // Non-admin toast will be handled by WebSocket event
+            eventBus.emit('resource/delete', { type: 'ai_news', id: itemId }); // For other UI updates
+          } else {
+            const errorData = await response.text();
+            Swal.fire('Errore!', `Si è verificato un errore durante l'eliminazione: ${errorData}`, 'error');
+          }
+        } catch (error) {
+          console.error('Errore fetch delete:', error);
+          Swal.fire('Errore!', 'Impossibile contattare il server.', 'error');
+        }
+      }
+    }
+  });
+}
+
+// Initialize on load or call this function when appropriate
+// initAiNewsDeleteConfirmation();

--- a/static/js/features/notifications/websocket.js
+++ b/static/js/features/notifications/websocket.js
@@ -48,50 +48,87 @@ eventBus.on('new_notification', (message) => {
 
 // Funzione helper per gestire gli eventi resource
 function handleResourceEvent(event, message) {
-  const { item, source_user_id } = message || {};
+  // message is the full object from eventBus, data is nested: { type: "resource/add", data: { item_type, item_id, user_id, ... } }
+  const eventData = message.data || {};
+  const { item_type, item_id, user_id: source_user_id, data_filter_criteria } = eventData;
+
   const currentUserId = document.body.dataset.userId;
   const currentUserRole = document.body.dataset.userRole;
 
-  saveDebugLog(`[WS] Ricevuto evento resource/${event}: ` + JSON.stringify({
-    item,
-    source_user_id,
-    currentUserId,
-    currentUserRole
-  }, null, 2));
+  saveDebugLog(`[WS] Ricevuto evento resource/${event}: ` + JSON.stringify(eventData, null, 2));
 
-  // Non mostrare il toast se l'utente corrente è quello che ha eseguito l'azione
-  // o se l'utente è admin
-  if (source_user_id === currentUserId || currentUserRole === 'admin') {
-    saveDebugLog(`[WS] Toast resource ignorato: ${source_user_id === currentUserId ? 'utente corrente è la fonte' : 'utente è admin'}`);
-    return;
+  // UI Refresh Logic - This should happen for all users, including the one who made the change,
+  // as their direct HTMX swap might not be the list itself.
+  // However, the server's direct response to an admin's action (e.g. new row, updated row) might already handle their UI.
+  // This WebSocket-triggered refresh is primarily for *other* clients.
+
+  let listElementId;
+  let listRefreshUrl;
+
+  if (item_type === 'ai_news') {
+    listElementId = 'ai-news-list'; // ID of the ai_news list container
+    listRefreshUrl = '/ai-news/list'; // URL to fetch the updated ai_news list partial
+  } else if (item_type === 'link') {
+    listElementId = 'links-list'; // ID of the links list container
+    listRefreshUrl = '/links/list';   // URL to fetch the updated links list partial
   }
+  // Add other resource types as needed
+
+  if (listElementId && listRefreshUrl) {
+    const listElement = document.getElementById(listElementId);
+    if (listElement) {
+      // Before refreshing, check if data_filter_criteria matches current view (advanced)
+      // For now, always refresh if the list element is present.
+      // This ensures other users see the changes.
+      // The user who made the change might get a more specific update from HTMX direct response.
+      console.log(`[WS] Triggering HTMX GET to refresh ${listElementId} from ${listRefreshUrl} due to resource/${event} for ${item_type}`);
+      htmx.ajax('GET', listRefreshUrl, {
+        target: `#${listElementId}`, // Ensure the target is the container that will be swapped
+        swap: 'outerHTML' // Or 'innerHTML' if the URL returns only the content of the list
+      });
+    }
+  }
+
+
+  // Toast Logic for other users (non-admin, not the source)
+  if (source_user_id === currentUserId || currentUserRole === 'admin') {
+    saveDebugLog(`[WS] Toast per resource/${event} ignorato: ${source_user_id === currentUserId ? 'utente corrente è la fonte' : 'utente è admin'}`);
+    return; // No toast for the user who made the change or for admins (admins get SweetAlerts)
+  }
+
+  const itemTitle = eventData.item_title || item_type; // Use item_title if available
 
   const eventMessages = {
     add: {
-      title: 'Nuova Risorsa',
-      body: `È stato aggiunto un nuovo elemento di tipo: ${item?.type}`,
+      title: 'Nuova Risorsa Aggiunta',
+      body: `Un nuovo elemento '${itemTitle}' (${item_type}) è stato aggiunto.`,
       type: 'success'
     },
     update: {
       title: 'Risorsa Aggiornata',
-      body: `È stato modificato un elemento di tipo: ${item?.type}`,
+      body: `L'elemento '${itemTitle}' (${item_type}) è stato aggiornato.`,
       type: 'info'
     },
     delete: {
       title: 'Risorsa Eliminata',
-      body: `È stato eliminato un elemento di tipo: ${item?.type}`,
+      body: `L'elemento '${itemTitle}' (${item_type}) è stato eliminato.`,
       type: 'warning'
     }
   };
 
-  const messageConfig = eventMessages[event];
+  const messageConfig = eventMessages[event]; // event is 'add', 'update', or 'delete'
   if (messageConfig) {
-    saveDebugLog(`[WS] Mostro toast per evento resource/${event}`);
+    saveDebugLog(`[WS] Mostro toast per evento resource/${event} a altri utenti`);
     showToast(messageConfig);
+    // Badge refresh might also be desired here if not covered by 'new_notification'
+    // htmx.trigger('body', 'notifications.refresh');
   }
 }
 
 // Aggiungiamo i listener per tutti gli eventi resource
+// The event bus emits the full message which includes 'type' and 'data'
+// So, when subscribing, the 'message' parameter in the callback will be this full object.
+// handleResourceEvent expects the 'event' string ('add', 'update', 'delete') and the 'message.data' part.
 eventBus.on('resource/add', (message) => handleResourceEvent('add', message));
 eventBus.on('resource/update', (message) => handleResourceEvent('update', message));
 eventBus.on('resource/delete', (message) => handleResourceEvent('delete', message)); 

--- a/templates/ai_news/list_partial.html
+++ b/templates/ai_news/list_partial.html
@@ -1,7 +1,6 @@
 <div id="ai-news-list" class="grid gap-4 mt-6"
-     hx-get="/ai-news/list/partial"
-     hx-trigger="update_ai_news from:body"
-     hx-swap="outerHTML">
+     hx-get="/ai-news/list/partial" {# This defines how the element can be refreshed if targeted by HTMX #}
+     hx-swap="outerHTML"> {# The WebSocket handler will now trigger the refresh using this URL and swap method #}
   <ul class="list-none p-0">
     {% for d in ai_news %}
       <li>

--- a/templates/ai_news/new_partial.html
+++ b/templates/ai_news/new_partial.html
@@ -1,0 +1,75 @@
+<h1 class="mb-10 text-center text-3xl font-bold text-slate-800">
+  Nuova AI news
+</h1>
+
+<form action="/ai-news/upload"
+      method="post"
+      enctype="multipart/form-data"
+      class="mx-auto grid max-w-lg gap-6"
+      hx-post="/ai-news/upload"
+      hx-encoding="multipart/form-data" {# Important for file uploads with HTMX #}
+      hx-swap="none">
+  <!-- Titolo -->
+  <div class="grid gap-2">
+    <label class="text-sm font-medium text-slate-700" for="title_ai_news_new">Titolo</label>
+    <input required name="title" id="title_ai_news_new" type="text" class="block w-full rounded-lg border border-slate-200 px-4 py-3 text-base focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50 transition">
+  </div>
+
+  <!-- Categoria -->
+  <div class="grid gap-2">
+    <label class="text-sm font-medium text-slate-700" for="category_ai_news_new">Categoria</label>
+    <select required name="category" id="category_ai_news_new" class="block w-full rounded-lg border border-slate-200 px-4 py-3 text-base focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50 transition">
+      <option value="">Seleziona una categoria</option>
+      <option value="generic">Generica</option>
+      <option value="business">Aziendale</option>
+      <option value="technical">Tecnica</option>
+      <option value="other">Altro</option>
+    </select>
+  </div>
+
+  <!-- File -->
+  <div class="grid gap-2">
+    <label class="text-sm font-medium text-slate-700" for="file_ai_news_new">File</label>
+    <input name="file" id="file_ai_news_new" type="file" class="block w-full rounded-lg border border-slate-200 px-4 py-3 text-base focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50 transition">
+    <p class="text-xs text-slate-500 mt-1">Carica un file oppure fornisci un URL esterno. Almeno un'opzione è richiesta.</p>
+  </div>
+
+  <!-- External URL -->
+  <div class="grid gap-2">
+    <label class="text-sm font-medium text-slate-700" for="external_url_ai_news_new">URL Esterno (alternativo al file)</label>
+    <input name="external_url" id="external_url_ai_news_new" type="url" class="block w-full rounded-lg border border-slate-200 px-4 py-3 text-base focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50 transition" placeholder="https://...">
+  </div>
+
+  <!-- Tags -->
+  <div class="grid gap-2">
+    <label class="text-sm font-medium text-slate-700" for="tags_ai_news_new">Tags (separati da virgola)</label>
+    <input name="tags" id="tags_ai_news_new" type="text" class="block w-full rounded-lg border border-slate-200 px-4 py-3 text-base focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50 transition" placeholder="es. Python, Tutorial, Framework">
+  </div>
+
+  <!-- ░░ Destinatario ░░ -->
+  <fieldset class="grid gap-4 border border-slate-300 rounded-lg p-4">
+    <legend class="px-2 text-sm font-semibold text-slate-600">Destinatario</legend>
+    {# Ensure this component provides unique IDs if used multiple times on a page or in modals #}
+    {% include "components/branch_and_hire_selects.html" with { "id_prefix": "ai_news_new" } %}
+  </fieldset>
+
+  <!-- Evidenza in home -->
+  <label class="inline-flex items-center gap-2 text-sm text-slate-700">
+    <input type="checkbox" id="show_on_home_ai_news_new" name="show_on_home" value="true" class="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500">
+    Metti in evidenza sulla home
+  </label>
+
+  <div class="flex gap-4 justify-end pt-4">
+    <button type="button"
+            data-close-modal
+            class="inline-flex items-center gap-1 rounded-lg bg-slate-100 px-6 py-2
+                   text-sm font-medium text-slate-700 shadow hover:bg-slate-200 transition">
+      Annulla
+    </button>
+    <button type="submit"
+            class="inline-flex items-center gap-1 rounded-lg bg-blue-600 px-6 py-2
+                   text-sm font-medium text-white shadow hover:bg-blue-700 transition">
+      Salva
+    </button>
+  </div>
+</form>

--- a/templates/ai_news/row_partial.html
+++ b/templates/ai_news/row_partial.html
@@ -66,9 +66,15 @@
         class="inline-flex items-center gap-1 rounded-lg bg-blue-100 px-4 py-2 text-sm font-medium text-blue-800 shadow hover:bg-blue-200 transition">
         Modifica
       </button>
-      <form hx-delete="/ai-news/{{ d._id }}" hx-target="#ai-news-{{ d._id }}" hx-swap="delete">
-        <button type="button" onclick="showDelete(this)"
-          class="inline-flex items-center gap-1 rounded-lg bg-rose-100 px-4 py-2 text-sm font-medium text-rose-700 shadow hover:bg-rose-200 transition">
+      <form hx-delete="/ai-news/{{ d._id }}"
+            hx-target="#ai-news-{{ d._id }}"
+            hx-swap="outerHTML" {# Use outerHTML to remove the whole div, or rely on JS event for removal #}
+            class="inline-block"> {# Ensure form itself is inline if button is to be side-by-side #}
+        <button type="button"
+                data-delete-url="/ai-news/{{ d._id }}"
+                data-item-id="{{ d._id }}"
+                data-item-name="{{ d.title }}"
+                class="inline-flex items-center gap-1 rounded-lg bg-rose-100 px-4 py-2 text-sm font-medium text-rose-700 shadow hover:bg-rose-200 transition">
           Elimina
         </button>
       </form>
@@ -211,134 +217,17 @@
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 
 <script type="module">
+  // Removed the specific delete and htmx:afterRequest handling from here.
+  // This will be handled by global scripts:
+  // - static/js/features/ai-news-delete.js for delete confirmation.
+  // - Global HTMX event listeners (e.g. in features/notifications/confirmations.js or similar) for admin SweetAlerts.
+  // - Global WebSocket listeners (e.g. in features/notifications/websocket.js and toast.js) for non-admin toasts.
   import { initAiNewsRow } from "/static/js/features/ai-news/index.js";
-  import { showToast } from '/static/js/features/notifications/toast.js';
-  import { eventBus } from '/static/js/core/event-bus.js';
   
   document.addEventListener('DOMContentLoaded', () => {
+    // Initialize other row-specific JS if any (e.g., like buttons, comment toggles)
+    // The initAiNewsRow function should focus on functionalities other than CRUD confirmations/feedback,
+    // or be adapted to not interfere with the global handlers.
     initAiNewsRow('{{ d._id }}');
-
-    // Gestione eliminazione
-    document.addEventListener('click', e => {
-      const deleteBtn = e.target.closest('[data-delete-url]');
-      
-      if (deleteBtn) {
-        e.preventDefault();
-        const url = deleteBtn.dataset.deleteUrl;
-        const newsId = deleteBtn.dataset.newsId;
-        const newsElement = document.querySelector(`#ai-news-${newsId}`);
-        
-        Swal.fire({
-          title: 'Sei sicuro?',
-          text: 'Questa azione non può essere annullata',
-          icon: 'warning',
-          showCancelButton: true,
-          confirmButtonText: 'Sì, elimina',
-          cancelButtonText: 'Annulla',
-          reverseButtons: true
-        }).then((result) => {
-          if (result.isConfirmed) {
-            // Facciamo la chiamata DELETE manualmente
-            fetch(url, {
-              method: 'DELETE',
-              headers: {
-                'HX-Request': 'true'
-              }
-            }).then(response => {
-              if (response.ok) {
-                // Prima rimuoviamo l'elemento dalla UI
-                if (newsElement) {
-                  newsElement.remove();
-                }
-
-                // Emettiamo l'evento sul bus
-                eventBus.emit('resource/delete', {
-                  type: 'ai_news',
-                  id: newsId
-                });
-
-                // Verifichiamo se c'è un trigger di conferma admin
-                response.headers.get('HX-Trigger')
-                  .then(triggerHeader => {
-                    console.log('HX-Trigger header:', triggerHeader);
-                    if (triggerHeader) {
-                      try {
-                        const trigger = JSON.parse(triggerHeader);
-                        if (trigger.showAdminConfirmation) {
-                          const { title, message, level, duration } = trigger.showAdminConfirmation;
-                          Swal.fire({
-                            title,
-                            text: message,
-                            icon: level,
-                            timer: duration,
-                            showConfirmButton: false
-                          });
-                        }
-                      } catch (e) {
-                        console.error('Errore nel parsing del trigger:', e);
-                        showToast({
-                          title: 'Operazione completata',
-                          body: 'La AI News è stata eliminata con successo',
-                          type: 'success'
-                        });
-                      }
-                    }
-                  });
-              } else {
-                showToast({
-                  title: 'Errore',
-                  body: 'Si è verificato un errore durante l\'eliminazione',
-                  type: 'error'
-                });
-              }
-            }).catch(error => {
-              console.error('Errore durante l\'eliminazione:', error);
-              showToast({
-                title: 'Errore',
-                body: 'Si è verificato un errore durante l\'eliminazione',
-                type: 'error'
-              });
-            });
-          }
-        });
-      }
-    });
-
-    // Ascolta eventi HTMX per mostrare toast di conferma
-    document.body.addEventListener('htmx:afterRequest', (evt) => {
-      if (evt.detail.successful && evt.detail.pathInfo.requestPath.includes('/ai-news/')) {
-        const triggerData = evt.detail.xhr.getResponseHeader('HX-Trigger');
-        let showToastNotification = true; // Default: mostra il toast
-
-        if (triggerData) {
-          try {
-            const triggers = JSON.parse(triggerData);
-            if (triggers.showAdminConfirmation) {
-              // Se c'è la conferma admin, mostra Swal e non mostrare il toast
-              showToastNotification = false;
-              const conf = triggers.showAdminConfirmation;
-              Swal.fire({
-                title: conf.title,
-                text: conf.message,
-                icon: conf.level,
-                timer: conf.duration,
-                showConfirmButton: false
-              });
-            }
-          } catch (e) {
-            console.error('Errore parsing trigger:', e);
-          }
-        }
-
-        // Mostra il toast se non c'è conferma admin (quindi per lo staff)
-        if (showToastNotification) {
-          showToast({
-            title: 'Operazione completata',
-            body: 'La AI News è stata aggiornata con successo',
-            type: 'success'
-          });
-        }
-      }
-    });
   });
 </script>


### PR DESCRIPTION
- Modified AI News backend (app/ai_news.py) CRUD operations (create, edit, delete) to match the patterns used in the Links section.
- Updated form handling for create/edit to use modals and process parameters (employment_type as list, show_on_home as bool) consistently.
- Standardized WebSocket event broadcasting for AI News (action notifications for toasts, resource events for UI updates) to align with Links.
- Implemented HX-Trigger headers for admin confirmations (SweetAlerts) and modal management (close, redirect) in AI News, similar to Links.
- Created templates/ai_news/new_partial.html for modal-based creation.
- Updated templates/ai_news/row_partial.html to use data attributes for a new JS delete handler and removed inline scripts.
- Created static/js/features/ai-news-delete.js for client-side delete confirmation using SweetAlert.
- Updated static/js/features/notifications/websocket.js to trigger HTMX list refreshes for AI News and Links based on resource events.
- Removed redundant hx-trigger from ai_news/list_partial.html.
- Cleaned up duplicate route definitions in app/ai_news.py.