### PR TITLE
Fix: Ensure link notification badge updates in real-time

### DIFF
--- a/templates/components/nav_links_badge.html
+++ b/templates/components/nav_links_badge.html
@@ -1,10 +1,11 @@
-<div id="nav-links-badge-container">
-  {% if unread_links_count %}
+<div id="nav-links-badge-container"
+     hx-get="/notifiche/count/link"
+     hx-trigger="notifications.refresh from:body"
+     hx-credentials="include"
+     hx-swap="innerHTML"
+     hx-target="this">
+  {% if unread_links_count and unread_links_count != "" and unread_links_count|int > 0 %}
   <span id="nav-links-badge"
-        hx-get="/notifiche/count/link"
-        hx-trigger="notifications.refresh from:body"
-        hx-credentials="include"
-        hx-swap="innerHTML"
         class="absolute -top-2 -right-2 bg-red-500 text-white text-xs font-bold rounded-full w-5 h-5 flex items-center justify-center">
     {{ unread_links_count }}
   </span>


### PR DESCRIPTION
- Modified nav_links_badge.html to move HTMX attributes to the always-present container div. This ensures that the badge can be refreshed even if it was initially not displayed (count was 0).
- Confirmed app/notifiche.py (notifiche_count_link) correctly provides data for the template.
- Confirmed app/links.py and notification_helpers.py correctly send a 'new_notification' WebSocket message that the frontend listens for to trigger badge refreshes.