### PR TITLE
Fix: Prevent WebSocket AssertionError for empty data

### DIFF
--- a/app/ws_broadcast.py
+++ b/app/ws_broadcast.py
@@ -98,7 +98,16 @@ async def broadcast_message(
         logger.debug("[WS] Nessuna connessione attiva")
         return
 
+    if not payload:
+        logger.error("[WS] Tentativo di invio payload vuoto, annullamento broadcast.")
+        return
+
     message_to_send = json.dumps(payload, ensure_ascii=False)
+
+    if not message_to_send or message_to_send == "{}": # Aggiunto controllo per stringa JSON vuota
+        logger.error(f"[WS] Messaggio serializzato vuoto o payload originale vuoto ({payload}), annullamento broadcast.")
+        return
+
     recipients = []
     
     logger.debug(f"[WS] Preparazione broadcast:")

--- a/static/js/features/notifications/websocket.js
+++ b/static/js/features/notifications/websocket.js
@@ -15,7 +15,12 @@ function saveDebugLog(message) {
 }
 
 eventBus.on('new_notification', (message) => {
-  const { title, body, level, source_user_id } = message.data || {};
+  if (!message || !message.data) {
+    saveDebugLog('[WS] Ricevuto messaggio "new_notification" invalido o senza dati. Messaggio: ' + JSON.stringify(message));
+    return;
+  }
+
+  const { title, body, level, source_user_id } = message.data; // Rimosso || {} perché il controllo sopra garantisce message.data
   const currentUserId = document.body.dataset.userId;
   const currentUserRole = document.body.dataset.userRole;
 


### PR DESCRIPTION
- Added checks in app/ws_broadcast.py to prevent sending empty or invalid payloads over WebSocket.
- Added checks in static/js/features/notifications/websocket.js to gracefully handle empty or invalid 'new_notification' messages received on the client-side.

This addresses the 'AssertionError: Data should not be empty' and improves WebSocket communication robustness.